### PR TITLE
otya128氏のメモリ処理変更を取り込んでみる

### DIFF
--- a/driver/itedtv_bus.c
+++ b/driver/itedtv_bus.c
@@ -245,11 +245,19 @@ static int itedtv_usb_alloc_urb_buffers(struct itedtv_usb_context *ctx,
 
 		if (!urb->transfer_buffer) {
 #ifdef __linux__
+#ifdef __GFP_RETRY_MAYFAIL
 			if (!no_dma)
 				p = usb_alloc_coherent(dev, buf_size,
-						       GFP_KERNEL, &dma);
+						       GFP_KERNEL | __GFP_RETRY_MAYFAIL, &dma);
 			else
-				p = kmalloc(buf_size, GFP_KERNEL);
+				p = kmalloc(buf_size, GFP_KERNEL | __GFP_RETRY_MAYFAIL);
+#else
+			if (!no_dma)
+				p = usb_alloc_coherent(dev, buf_size,
+						       GFP_KERNEL | __GFP_REPEAT, &dma);
+			else
+				p = kmalloc(buf_size, GFP_KERNEL | __GFP_REPEAT);
+#endif
 #else
 			p = kmalloc(buf_size, GFP_KERNEL);
 #endif

--- a/driver/itedtv_bus.c
+++ b/driver/itedtv_bus.c
@@ -363,27 +363,27 @@ static void itedtv_usb_free_urb_buffers(struct itedtv_usb_context *ctx,
 	return;
 }
 
-static void itedtv_usb_clean_context(struct itedtv_usb_context *ctx)
+static void itedtv_usb_clean_context(struct itedtv_usb_context *ctx, bool free_works)
 {
 #ifdef ITEDTV_BUS_USE_WORKQUEUE
 	if (ctx->wq)
 		destroy_workqueue(ctx->wq);
 #endif
 
-	if (ctx->works) {
+	if (free_works && ctx->works) {
 		itedtv_usb_free_urb_buffers(ctx, true);
 		kfree(ctx->works);
+		ctx->num_urb = 0;
+		ctx->works = NULL;
+		ctx->num_works = 0;
 	}
 
 	ctx->stream_handler = NULL;
 	ctx->ctx = NULL;
-	ctx->num_urb = 0;
 	ctx->no_dma = false;
 #ifdef ITEDTV_BUS_USE_WORKQUEUE
 	ctx->wq = NULL;
 #endif
-	ctx->num_works = 0;
-	ctx->works = NULL;
 
 	return;
 }
@@ -481,7 +481,7 @@ fail:
 		flush_workqueue(ctx->wq);
 #endif
 
-	itedtv_usb_clean_context(ctx);
+	itedtv_usb_clean_context(ctx, true);
 
 	mutex_unlock(&ctx->lock);
 
@@ -512,7 +512,7 @@ static int itedtv_usb_stop_streaming(struct itedtv_bus *bus)
 			usb_kill_urb(works[i].urb);
 	}
 
-	itedtv_usb_clean_context(ctx);
+	itedtv_usb_clean_context(ctx, false);
 
 	mutex_unlock(&ctx->lock);
 
@@ -603,6 +603,7 @@ int itedtv_bus_term(struct itedtv_bus *bus)
 			if (atomic_read_acquire(&ctx->streaming))
 				itedtv_usb_stop_streaming(bus);
 
+			itedtv_usb_clean_context(ctx, true);
 			mutex_destroy(&ctx->lock);
 			kfree(ctx);
 		}

--- a/driver/ptx_chrdev.c
+++ b/driver/ptx_chrdev.c
@@ -226,7 +226,7 @@ static long ptx_chrdev_unlocked_ioctl(struct file *file,
 				break;
 			} else if (freq.freq_no < 12) {
 				/* BS */
-				if (freq.slot >= 8) {
+				if (0 && freq.slot >= 8) {
 					ret = -EINVAL;
 					break;
 				}
@@ -268,7 +268,7 @@ static long ptx_chrdev_unlocked_ioctl(struct file *file,
 					break;
 				} else if (freq.freq_no < 12) {
 					/* BS */
-					if (freq.slot >= 8) {
+					if (0 && freq.slot >= 8) {
 						ret = -EINVAL;
 						break;
 					}

--- a/driver/ringbuffer.c
+++ b/driver/ringbuffer.c
@@ -104,8 +104,13 @@ int ringbuffer_alloc(struct ringbuffer *ringbuf, size_t size)
 	ringbuffer_reset_nolock(ringbuf);
 
 	if (!ringbuf->buf) {
-		ringbuf->buf = (u8 *)__get_free_pages(GFP_KERNEL,
+#ifdef __GFP_RETRY_MAYFAIL
+		ringbuf->buf = (u8 *)__get_free_pages(GFP_KERNEL | __GFP_RETRY_MAYFAIL,
 						      get_order(size));
+#else
+		ringbuf->buf = (u8 *)__get_free_pages(GFP_KERNEL | __GFP_REPEAT,
+						      get_order(size));
+#endif
 		if (!ringbuf->buf)
 			ret = -ENOMEM;
 		else


### PR DESCRIPTION
複数チューナーを接続し、1週間以上の稼働をさせたときに以下のエラーが出ていたので、 otya128氏の変更を取り込んでみます。

```
[900240.717291] recpt1: page allocation failure: order:6, mode:0xcc1(GFP_KERNEL|GFP_DMA), nodemask=(null),cpuset=docker-acafe2b53312a852d930a88ee1af172ddd88659cda02627430f0910480cafbf0.scope,mems_allowed=0
[900240.717357] CPU: 0 PID: 119625 Comm: recpt1 Tainted: G           O      5.10.110-rockchip-rk3588 #23.02.2
[900240.717366] Hardware name: Orange Pi 5 (DT)
[900240.717379] Call trace:
[900240.717403]  dump_backtrace+0x0/0x1a8
[900240.717419]  show_stack+0x20/0x2c
[900240.717439]  dump_stack_lvl+0xcc/0xfc
[900240.717451]  dump_stack+0x18/0x34
[900240.717470]  warn_alloc+0xec/0x168
[900240.717486]  __alloc_pages_slowpath.constprop.145+0x218/0x738
[900240.717501]  __alloc_pages_nodemask+0x190/0x258
[900240.717520]  __dma_direct_alloc_pages+0xdc/0x1a0
[900240.717533]  dma_direct_alloc+0x150/0x274
[900240.717546]  dma_alloc_attrs+0xb8/0xf4
[900240.717562]  hcd_buffer_alloc+0xb4/0xc0
[900240.717580]  usb_alloc_coherent+0x24/0x34
[900240.717627]  itedtv_usb_start_streaming+0x184/0x418 [px4_drv]
[900240.717660]  isdb2056_chrdev_set_capture+0xf0/0x214 [px4_drv]
[900240.717694]  ptx_chrdev_unlocked_ioctl+0x450/0x624 [px4_drv]
[900240.717710]  vfs_ioctl+0x30/0x50
[900240.717723]  __arm64_sys_ioctl+0x80/0xb4
[900240.717738]  el0_svc_common.constprop.5+0x13c/0x1f0
[900240.717750]  do_el0_svc+0x84/0xa4
[900240.717764]  el0_svc+0x20/0x30
[900240.717776]  el0_sync_handler+0x68/0x134
[900240.717789]  el0_sync+0x180/0x1c0
[900240.717798] Mem-Info:
[900240.717831] active_anon:78698 inactive_anon:85892 isolated_anon:0
                 active_file:1030506 inactive_file:461141 isolated_file:0
                 unevictable:0 dirty:5 writeback:0
                 slab_reclaimable:43056 slab_unreclaimable:18700
                 mapped:35782 shmem:3459 pagetables:2219 bounce:0
                 free:146588 free_pcp:0 free_cma:17
[900240.717856] Node 0 active_anon:314792kB inactive_anon:343568kB active_file:4122024kB inactive_file:1844564kB unevictable:0kB isolated(anon):0kB isolated(file):0kB mapped:143128kB dirty:20kB writeback:0kB shmem:13836kB writeback_tmp:0kB kernel_stack:8080kB all_unreclaimable? no
[900240.717887] DMA free:573412kB min:5444kB low:9256kB high:13068kB reserved_highatomic:0KB active_anon:21440kB inactive_anon:161964kB active_file:2071244kB inactive_file:687864kB unevictable:0kB writepending:0kB present:3930112kB managed:3837208kB mlocked:0kB pagetables:732kB bounce:0kB free_pcp:0kB local_pcp:0kB free_cma:0kB
[900240.717895] lowmem_reserve[]: 0 0 3941 3941
[900240.717951] Normal free:12940kB min:5760kB low:9796kB high:13832kB reserved_highatomic:0KB active_anon:293352kB inactive_anon:181604kB active_file:2050780kB inactive_file:1156696kB unevictable:0kB writepending:20kB present:4194304kB managed:4036564kB mlocked:0kB pagetables:8144kB bounce:0kB free_pcp:0kB local_pcp:0kB free_cma:68kB
[900240.717958] lowmem_reserve[]: 0 0 0 0
[900240.717992] DMA: 11462*4kB (UME) 14633*8kB (UME) 7881*16kB (UME) 3283*32kB (UME) 1546*64kB (UME) 636*128kB (UME) 0*256kB 0*512kB 0*1024kB 0*2048kB 0*4096kB = 574416kB
[900240.718116] Normal: 633*4kB (UMEC) 729*8kB (UMEC) 219*16kB (UM) 49*32kB (U) 0*64kB 0*128kB 0*256kB 0*512kB 0*1024kB 0*2048kB 0*4096kB = 13436kB
```